### PR TITLE
Fix file service naming and implement stream copy

### DIFF
--- a/src/main/java/net/cactus/service/FileService.java
+++ b/src/main/java/net/cactus/service/FileService.java
@@ -17,9 +17,9 @@ public interface FileService {
 
     String saveFile(File file);
 
-    byte[] getFileThrougnBytes(String fileKey) throws IOException;
+    byte[] getFileThroughBytes(String fileKey) throws IOException;
 
-    void getFileThrouthStream(String fileKey, OutputStream output) throws Exception;
+    void getFileThroughStream(String fileKey, OutputStream output) throws Exception;
 
     FileMeta getFileInfo(String fileKey) throws Exception;
 

--- a/src/main/java/net/cactus/service/impl/FileServiceImpl.java
+++ b/src/main/java/net/cactus/service/impl/FileServiceImpl.java
@@ -1,7 +1,6 @@
 package net.cactus.service.impl;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -49,15 +48,22 @@ public class FileServiceImpl extends AbstractService implements FileService {
     }
 
     @Override 
-    public byte[] getFileThrougnBytes(String fileKey) throws IOException {
+    public byte[] getFileThroughBytes(String fileKey) throws IOException {
         File file = this.storageService.getFileByKey(fileKey).toFile();
         return FileUtils.readFileToByteArray(file);
     }
 
-    @Override 
-    public void getFileThrouthStream(String uuid, OutputStream output) throws Exception {
+    @Override
+    public void getFileThroughStream(String uuid, OutputStream output) throws Exception {
         File file = this.storageService.getFileByKey(uuid).toFile();
-        new FileOutputStream(file);
+        try (InputStream in = FileUtils.openInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int len;
+            while ((len = in.read(buffer)) != -1) {
+                output.write(buffer, 0, len);
+            }
+            output.flush();
+        }
     }
 
     @Override 


### PR DESCRIPTION
## Summary
- rename `getFileThrougnBytes` and `getFileThrouthStream` to clearer names
- implement `getFileThroughStream` with byte copy

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687106bd1d24832086f5a570028f87df