### PR TITLE
Externalize DB credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,16 @@ nohup soffice --headless --accept="socket,host=127.0.0.1,port=2002;urp;" --nofir
 ```
 
 ### 3. 配置文件
-修改 `application.yml` 中的数据库连接：
+修改 `application.yml` 中的数据库连接，推荐通过环境变量或独立的 `jdbc.properties` 提供凭证：
 ```yaml
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/fileserver
-    username: your_username
-    password: your_password
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 ```
+
+如需使用文件方式配置，可在 `src/main/resources` 目录下创建 `jdbc.properties`，其中定义 `DB_USERNAME` 和 `DB_PASSWORD` 两个属性。
 
 ### 4. 运行应用
 ```bash

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,8 +11,8 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://192.168.1.19:3306/fileserver?useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true&nullCatalogMeansCurrent=true&connectTimeout=60000&socketTimeout=60000
-    username: root
-    password: Nstr.234808
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     hikari:
       maximum-pool-size: 20
       minimum-idle: 5


### PR DESCRIPTION
## Summary
- reference DB credentials via environment variables
- update documentation for DB credential configuration

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871069cc03483208b17f9f7c13f459a